### PR TITLE
Fixed warnings and notices issued by PHP 8.1.4

### DIFF
--- a/mapcode_api.php
+++ b/mapcode_api.php
@@ -639,7 +639,7 @@ function decodeTriple($input)
     $c1 = decodeChar($input);
     $x = decodeBase31(substr($input, 1));
     if ($x < 0) {
-        return 0;
+        return null;
     }
     if ($c1 < 24) {
         return new Coord((int)($c1 / 6) * 34 + (int)($x % 34), ($c1 % 6) * 28 + (int)($x / 34));
@@ -781,7 +781,7 @@ function decodeGrid($input, $extensionchars, $m)
 
     if ($postfixlength == 3) {
         $d = decodeTriple($rest);
-        if ($d == 0) {
+        if (!$d) {
             return new MapcodeZone();
         }
         $difx = $d->lon;
@@ -961,7 +961,7 @@ function decodeAutoHeader($input, $extensionchars, $m)
     }
     $value *= (961 * 31);
     $triple = decodeTriple(substr($input, strlen($input) - 3));
-    if ($triple == 0) {
+    if (!$triple) {
         return new MapcodeZone();
     }
     for (; Codex($m) == $codexm; $m++) {
@@ -1239,7 +1239,7 @@ function to_ascii($str)
     }
     $p = strrpos($result, ' ');
     if ($p === false) $p = 0; else $p++;
-    if ($result[$p] == 'A') {
+    if ((strlen($result)) && ($result[$p] == 'A')) {
         $result = substr($result, 0, $p) . aeu_pack(aeu_unpack(substr($result, $p)));
     }
     return $result;
@@ -1454,7 +1454,7 @@ function decode($mapcodeString, $territory = -1)
     } else {
         return master_decode($mapcodeString, $contextTerritoryNumber);
     }
-    return 0;
+    return null;
 }
 
 function encodeSixWide($x, $y, $width, $height)

--- a/mapcode_api.php
+++ b/mapcode_api.php
@@ -1783,7 +1783,7 @@ function mapcoderEngine($enc, $tn, $getshortest, $isrecursive, $state_override, 
     if (is_numeric($tn) && $tn >= 0 && $tn <= $uptoRun) {
         $fromRun = $tn;
         $uptoRun = $tn;
-    } else if ($GLOBALS['redivar']) {
+    } else if (array_key_exists('redivar', $GLOBALS)) {
         $use_redivar = 1;
         $HOR = 1;
         $i = 0; // pointer into redivar

--- a/sample.php
+++ b/sample.php
@@ -34,7 +34,11 @@
 
     echo '<H1>Mapcode PHP version ' . mapcode_phpversion . ' example</H1>';
 
-    $input = trim($_REQUEST["s"]);
+    if (array_key_exists('s', $_REQUEST)) {
+        $input = trim($_REQUEST["s"]);
+    } else {
+        $input = NULL;
+    }
     if ($input != NULL) {
         //$input = utf8_decode(mb_convert_encoding($input,"utf-8" ));
         if (strpos($input, ',') !== false) // contains a comma, so assume coordinates
@@ -60,7 +64,7 @@
                 echo ' (romanized as ' . $asc . ')';
             }
             $d = decode($input);
-            if ($d == 0) {
+            if (!$d) {
                 echo '<BR>is not a valid mapcode<BR>';
                 if (strpos($input, ' ') === false) {
                     echo '(did you include the territory?)<BR>';

--- a/unittest/unittest.php
+++ b/unittest/unittest.php
@@ -40,8 +40,8 @@ include '../mapcode_api.php';
 include 'test_territories.php';
 include 'test_encodes.php';
 
-ini_set('max_execution_time', 300);
-set_time_limit(300);
+ini_set('max_execution_time', 1200);
+set_time_limit(1200);
 
 echo "Mapcode Unittest version 2.2<BR>";
 echo "Mapcode PHP version " . mapcode_phpversion . "<BR>";
@@ -167,7 +167,7 @@ function test_encode_decode($str, $y, $x, $localsolutions, $globalsolutions)
             $str = $r[$i];
             // check if every solution decodes
             $p = decode($str);
-            if ($p == 0) {
+            if (!$p) {
                 $GLOBALS['nrErrors']++;
                 echo '*** ERROR *** decode(' . $str . ') = no result. expected ~(' . number_format($y, 14) . ' . ' . number_format($x, 14) . ')<BR>';
             } else {
@@ -340,7 +340,12 @@ function test_encodes()
     while ($t[$n * 5] !== false) $n++;
 
     // executed (optionally, from "start" parameter)
-    $i = intval($_GET["start"]) - 1;
+    if (array_key_exists("start", $_GET)) {
+        $i = intval($_GET["start"]) - 1;
+    } else {
+        $i = 0;
+    }
+    
     if ($i < 0) $i = 0;
     $nextlevel = $i;
     while ($i <= $n) {
@@ -419,7 +424,7 @@ function territory_code_tests()
         "USA", -1, "US OTHER TEXT",
         "USA", -1, "   US OTHER TEXT   ",
         "US-CA", -1, "US-CA",
-        "US-CA", -1 - 1, "US-CA OTHER TEXT",
+        "US-CA", -1, "US-CA OTHER TEXT",
         "US-CA", -1, "USA-CA",
         "RU-TT", -1, "RUS-TAM",
         -1, -1, "RUS-TAMX",
@@ -498,7 +503,11 @@ test_encodes(); // uses test_encode_decode()
 
 echo '<HR>Edge encode/decode tests <font id="prog1">0</font>%<BR>';
 {
-    $i = intval($_GET["edge"]);
+    if (array_key_exists("edge", $_GET)) {
+        $i = intval($_GET["edge"]);
+    } else {
+        $i = 0;
+    }
     if ($i > 0) $GLOBALS['next_corner_to_test'] = $i;
     while (test_corner_encodes()) ;
 }


### PR DESCRIPTION
several api functions (decodeTriple and decode) returned either an object or an int 0. This leads to warnings in the calling code under PHP 8.1. As a fix, these functions now return null rather than 0.

In various places, associative arrays were accessed using non-existing keys. E.g. $GLOBALS['redivar'], $_REQUEST['s'], $_GET['edge'] and $_GET['start']. Code has been extended to avoid such access.

In the function territory_code_tests() in unittest.php, there was a $testdata array entry for 'US-CA OTHER TEXT' having a context of '-1 -1'. This is evaluated as -2 and that leads to a warning in PHP 8.1. The context has been fixed to '-1'

Indexing into an uninitialized array leads to warning in PHP 8.1. This has been fixed for accessing $result[$p] in to_ascii()